### PR TITLE
Provide 2FA information in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # glovo-interview-android-base
 
-Please build this empty project to have all the dependencies on your machine before your live coding interview.
+This repository contains all the dependencies that you might need to use during the Glovo Live Coding interview. Please build this empty project to have all the dependencies cached on your machine before the interview starts, so the process will be smoother. :)
+
+For the Live Coding interview, you will be invited to a private Glovo repository. You must have [2 Factor Authentication](https://docs.github.com/en/github/authenticating-to-github/securing-your-account-with-two-factor-authentication-2fa) enabled in your account in order to access to the repository.
+
+Keep in mind that 2FA involves updating your [command line Git configuration](https://docs.github.com/en/github/authenticating-to-github/accessing-github-using-two-factor-authentication#using-two-factor-authentication-with-the-command-line) as well.
+
+Make sure to have everything ready before the interview, so you can focus in the challenge instead of wasting time configuring the account.
 
 Good luck :)


### PR DESCRIPTION
Be more explicit in the README about the 2FA configuration that candidates need to do before the interview.