### PR TITLE
[NOTICKET] Fix gson version (synk report)

### DIFF
--- a/dependencies.gradle.kts
+++ b/dependencies.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
     "implementation"("com.squareup.retrofit2:retrofit:2.9.0")
     "implementation"("com.squareup.retrofit2:converter-gson:2.9.0")
     "implementation"("com.squareup.retrofit2:adapter-rxjava2:2.6.4")
-    "implementation"("com.google.code.gson:gson:2.8.7")
+    "implementation"("com.google.code.gson:gson:2.8.9")
     "implementation"("com.squareup.okhttp3:okhttp:4.9.1")
     "implementation"("com.squareup.okhttp3:okhttp-urlconnection:4.9.1")
     "implementation"("com.squareup.okhttp3:logging-interceptor:4.9.1")


### PR DESCRIPTION
## Description
Update `gson` from: `2.8.7` to `2.8.9` 

## Context 
Working at [PR #352](https://github.com/Glovo/courier-eta/pull/352), synk security report pop up blocking setting the `gson` version to `2.8.7`. So, updating it here as well. Severity: `high`. As there are only a [few](https://sourcegraph.glovoint.com/search?q=context:global+gson:2.8.7&patternType=literal) services on `2.8.7`, updating them. 

<img width="1427" alt="image" src="https://user-images.githubusercontent.com/1021909/148941945-7dfc6f80-c362-42d7-a14d-0ce778d48b99.png">