### PR TITLE
[PEAR] Update gradle wrapper and use its bin distribution

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip


### PR DESCRIPTION
## What does this PR do?
Update gradle wrapper to version `8.5`.
Use the `bin` type instead of `all` as it's smaller by ~40%, which means faster project loading times for candidates and less waiting time in general to download dependencies.

I also updated gradle in the feed project: https://github.com/Glovo/glovo-interview-android-feed/pull/41


<img width="327" alt="Screenshot 2024-01-17 at 13 06 52" src="https://github.com/Glovo/glovo-interview-android-feed/assets/6529875/f22a2828-b7a2-4b2d-af7e-58a3d4ea6ba9">
<img width="319" alt="Screenshot 2024-01-17 at 13 16 51" src="https://github.com/Glovo/glovo-interview-android-feed/assets/6529875/88aaf314-b0e5-49f1-803e-42107d4648e2">






